### PR TITLE
Remove CSS causing li overlap, fixes #4

### DIFF
--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -1135,25 +1135,7 @@ a[id]{
 }
 
 @media screen and (min-width: 711.11px){
-
-	.layout-table-of-contents .wrapper ol li.agreements,
-	.layout-table-of-contents .wrapper ol li.bookmarks,
-	.layout-table-of-contents .wrapper ol li.checklist{
-		float: left;
-		width: 50%;
-		margin-right: 0.6em;
-	}
-
-	.layout-table-of-contents .wrapper ol li.equipment,
-	.layout-table-of-contents .wrapper ol li.networks{
-		float: right;
-		width: 48.5%;
-	}
-
-	.layout-table-of-contents .wrapper ol li.equipment{ margin-top: -2.8em; }
-	.layout-table-of-contents .wrapper ol li.networks{ margin-top: -1.4em; }
-
-		.layout-table-of-contents .wrapper ol li.tools{ clear: both; }
+	.layout-table-of-contents .wrapper ol li.tools{ clear: both; }
 
 	.layout-table-of-contents .wrapper ol li.classes > ol,
 	.layout-table-of-contents .wrapper ol li.equipment  > ol,

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -1135,8 +1135,8 @@ a[id]{
 }
 
 @media screen and (min-width: 711.11px){
-	.toc-nav-children {
-  	clear: both;
+	.toc-nav-children,
+  .toc-nav-grandchildren {
   	-webkit-column-count: 2;
   	-moz-column-count: 2;
   	column-count: 2;
@@ -1144,12 +1144,6 @@ a[id]{
 
   .toc-nav-child-with-children {
     column-span: all;
-  }
-
-  .toc-nav-grandchildren {
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
-    column-count: 2;
   }
 }
 


### PR DESCRIPTION
Removes the overlap of Equipment and Networks on Table of Contents page cause by CSS originally intended to enforce two-column appearance in complex nested `ol` structure. Now only appears as a single column. This also affects the first list in the Welcome to 18F section.

Recommend revision to `index.html` and `stylesheets/screen.css` to simplify nesting and increase control over creation of two-column lists.

Fixes issue #4 

Before:
![screen shot 2016-07-26 at 1 59 17 pm](https://cloud.githubusercontent.com/assets/2487968/17149437/449d424e-5339-11e6-8d76-1620eab673f0.png)

After:
![screen shot 2016-07-26 at 2 00 25 pm](https://cloud.githubusercontent.com/assets/2487968/17149450/55d49dc8-5339-11e6-9cc0-e446042618d9.png)

