### PR TITLE
Move printer IP addresses and information to Google Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -286,9 +286,6 @@ navigation:
     - text: Trello
       url: trello/
       internal: true
-    - text: Ubuntu
-      url: ubuntu/
-      internal: true
     - text: VMware Horizon
       url: vmware-horizon/
       internal: true

--- a/_pages/about-us/offices/chicago.md
+++ b/_pages/about-us/offices/chicago.md
@@ -139,6 +139,10 @@ Lockers are to your left and right when you walk inside the door.
 
 If you need pens, paper, and other office supplies, there are a few items above the coffee making area.
 
+### <a id="printers"></a>Printers
+
+Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
+
 ## <a id="amenities"></a>Amenities
 
 ### <a id="transit-subsidy"></a>Transit subsidy

--- a/_pages/about-us/offices/new-york-city.md
+++ b/_pages/about-us/offices/new-york-city.md
@@ -114,10 +114,9 @@ You can book large rooms for meetings, but Phone Rooms can also be booked for ca
 
 Note: You will need to have a Civic Hall membership to book a room. If you're visiting NYC, post in #nyc to have someone here book your room with their log in.
 
+### <a id="printers"></a>Printers
 
-### <a id="access-a-printer"></a>Access a printer?
-
-The IP address is clearly labeled on the printer itself, `192.168.10.40`. You should be able to enter that as a printer IP for it to auto-detect and work.
+Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
 
 ### <a id="get-on-the-wireless"></a>Get on the wireless?
 

--- a/_pages/about-us/offices/san-francisco.md
+++ b/_pages/about-us/offices/san-francisco.md
@@ -143,15 +143,7 @@ Wireless works well in the beautiful courtyard, so work outside for a change!
 
 ### <a id="access-a-printer">Access a printer?</a>
 
-The printer is located at the far end of the office. The IP address is `172.30.93.49`.
-
-To set up a printer on a Mac:
-
-1. Open System Preferences.
-2. Click Printers and Scanners.
-3. Click the `+` button.
-4. Click the `IP` tab. Enter `172.30.93.49` in the address line.
-5. Click `Add`. The printer model is a Xerox WorkCentre 7855.
+Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
 
 ### <a id="wifi">Get on the wireless?</a>
 

--- a/_pages/about-us/offices/washington-dc.md
+++ b/_pages/about-us/offices/washington-dc.md
@@ -127,14 +127,9 @@ If you're expecting a small group of US citizens (fewer than 15 or so), no advan
 
 If you're expecting a large group, or if the group includes non-US citizens, you should give security advance notice.
 
-### <a id="access-a-printer">Access a printer? </a>
+### <a id="access-a-printer">Access a printer?</a>
 
-To set up a printer on a Mac, go to System Preferences and find Printers and Scanners. Press the `+` button and then click on the IP tab. Type `192.168.24.107` or `192.168.25.57` in the address line and click `Add`.
-
-Printer location: Printers are located in 4400 infill (Room 4231)
-
-> The printers will sometimes say there&rsquo;s a paper jam if you&rsquo;re on the `gsa-guest` wifi, when there isn&rsquo;t a paper jam.  If you switch to `gsa-wireless`, it will magically start working.
-
+Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
 
 ### <a id="get-on-the">Get on the wireless? </a>
 


### PR DESCRIPTION
This moves the printer IP addresses and related info for the DC, SF, NYC, and Chicago offices to a Google Doc that is shared with all of GSA.