### PR TITLE
remove unnecessary anchor links

### DIFF
--- a/_pages/about-us/offices/san-francisco.md
+++ b/_pages/about-us/offices/san-francisco.md
@@ -53,7 +53,7 @@ title: San Francisco
 </div>
 
 
-## <a id="the-building">The building</a>
+## The building
 
 [50 UN Plaza](http://www.gsa.gov/portal/category/107031) is on historic Market Street between 6th and 7th streets, in the Civic Center neighborhood. The Bay Area Rapid Transit authority (BART) and MUNI both have underground stops at this location, and the historic F Market streetcar line has two local stops at 6th and 7th Streets.
 
@@ -61,25 +61,25 @@ title: San Francisco
 
 There is a lively farmers market literally out our door every Wednesday. There are many historic buildings within walking distance &mdash; San Francisco City Hall and the Asian Art Museum are but two of them!
 
-## <a id="getting-here">Getting here</a>
+## Getting here
 
-### <a id="from-sfo">From San Francisco International Airport (SFO)</a>
+### From San Francisco International Airport (SFO)
 
 Public transit from SFO to the 18F San Francisco office is cheap, fairly quick, and convenient. Take the AirTrain from your terminal of arrival to the SFO BART station. Trains run from the airport to downtown between 15 minutes and 20 minutes with the actual travel time around 35 minutes. The office sits right above the Civic Center stop for BART.
 
-### <a id="from-oak">From Oakland International Airport (OAK)</a>
+### From Oakland International Airport (OAK)
 
 The smaller of the two San Francisco area airports, OAK is just across the bay from downtown. You can hop on the automated monorail from the airport, then change to the BART system train at OAK/Coliseum station. It&rsquo;s a 25 minute ride to Civic Center BART station.
 
 BART Service is M–F, 4 a.m. to midnight; the last train is generally 10 to 15 minutes after the hour. Saturday service is 6 a.m. to midnight. Sunday service is 8 a.m. to midnight.
 
 
-### <a id="walking">Walking</a>
+### Walking
 
 San Francisco is a very walkable city; there are plenty of hotels, coffee shops, restaurants, and bars within walking distance of the office. Via the F Market streetcar, you can get to the Castro in one direction, or hop on the other direction to the Ferry Building and the piers overlooking the Bay.
 
 
-### <a id="biking">Biking</a>
+### Biking
 
 There is a developing [bikeshare program](http://www.bayareabikeshare.com) in the city of San Francisco.
 
@@ -88,39 +88,39 @@ Bike parking is next to the loading dock, entered from the far corner at McAllis
 If you have any questions about this, contact [Victor Valdivizeo](https://18f.slack.com/team/vv).
 
 
-### <a id="public-transit">Public transit</a>
+### Public transit
 
 San Francisco is very accessible by its public transportation system, [SFMTA](https://www.sfmta.com/). The larger Bay Area is also accessible via [BART](http://www.bart.gov/). Taxis, while available, aren&rsquo;t generally necessary for getting around the city, which is only approximately 7 square miles.
 
 [Clipper Card](https://www.clippercard.com/ClipperWeb/) is the Bay Area&rsquo;s transit pass. It works on many of the different public transit systems, including SFMTA and BART. SFMTA one-way fare is $2.25 with a 90-minute transfer (although sometimes you get a bit lengthier time for your transfer). BART fares are based on distance. SFO to Civic Center Station is $8.65; OAK to Civic Center Station is $10.05. See [BART&rsquo;s website](http://www.bart.gov/) for further fare prices.
 
 
-### <a id="parking">Parking</a>
+### Parking
 
 Don&rsquo;t do it! Your best bet is public transit and/or walking; downtown streets have one ways and can be very confusing. Street parking is horrible, and paid parking is way expensive. But if you do drive, you may park at 355 McAllister Street. The hours for this underground parking structure are 6 a.m. to midnight M–F. Fees vary but $4.50 to $2.00 per hour depending on when you enter garage.
 
 
-## <a id="how-do-i">How do I&hellip;</a>
+## How do I&hellip;
 
 You can also learn more about the building's features in the [50UNP Electronic Tenant Handbook on InSite](https://insite.gsa.gov/portal/content/612542) and the [50UNP Tenants page](http://www.gsa.gov/portal/category/106999).
 
-### <a id="enter-the-building">Enter the building for the first time?</a>
+### Enter the building for the first time?
 
 During business hours (6 a.m. to 6 p.m.), pass through security with your badge visible. Your GSA ID grants you access to the building at any time during those hours.
 
 If you’re having trouble, call one of the points of contact listed above, or give a shout in the #sf channel on Slack.
 
-###<a id="get-my-fingerprints">Get my fingerprints and badge?</a>
+### Get my fingerprints and badge?
 
 You can get them at 450 Golden Gate. [Schedule an appointment](https://timetrade.com/app/usaccess/workflows/usaccess001/schedule/location?wfsid=b07a7e11-baba97f6-b07a7e14-baba97f6-00000003-6ndldh7l376heqavd2983aah4s7tsj4b&appointmentTypeGroupId=hspd12&fs=1). They also have open office hours all day Monday for GSA employees.
 
 Once you’re there, turn right after entering past security, then the MSO office is directly across from IRS. This is also where you can get your card _activated_.
 
-### <a id="attend-orientation">Attend GSA and 18F orientation?</a>
+### Attend GSA and 18F orientation?
 
 GSA onboarding is typically conducted on Mondays at 50 UN Plaza. 18F SF onboarding takes place after GSA orientation at our office suite. You should receive an email confirming the times that you will meet with your team.
 
-### <a id="guests">Bring in guests?</a>
+### Bring in guests?
 
 Meet your guests at the front security desk to escort them in.
 
@@ -128,42 +128,42 @@ Be aware that IDs from [a few states](https://www.dhs.gov/current-status-states-
 
 If you’re inviting guests to a potluck, point them to our handy [Eventbrite invite](https://www.eventbrite.com/e/18f-potluck-lunch-tickets-9543876993) with all of the security details.
 
-### <a id="access-the-building">Access the building after hours?</a>
+### Access the building after hours?
 
 If you're a visitor arriving outside business hours, arrange for an 18F staff member inside the office to escort you.
 
 If you're based in SF and want to regularly access the building after hours, you need to fill out the [50 UNP Security Access Card Application](https://drive.google.com/a/gsa.gov/file/d/0BxUQGw0LW4R9RTl5ZWl3YzF1RzQ/view?ts=5605883f). Have someone of authority sign it for you (like Hillary Hartley or Patrick Bateman), then send to the <a href="#helpful-contacts">building manager</a>. Email [Rachel Almeida](mailto:rachel.almeida@gsa.gov) to set up a time to get your fingerprints taken and badge coded for access. Bring your form with you.
 
 
-### <a id="book-rooms">Book rooms for meetings?</a>
+### Book rooms for meetings?
 
 The SF office has small team rooms. You can book other conference rooms using [BookIt!](/gsa-tools-equipment-and-transit/#bookit) Recommended rooms include Yuma and Carson City, because they are [Acano](/acano)-friendly.
 
 Wireless works well in the beautiful courtyard, so work outside for a change!
 
-### <a id="access-a-printer">Access a printer?</a>
+### Access a printer?
 
 Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
 
-### <a id="wifi">Get on the wireless?</a>
+### Get on the wireless?
 
 The guest Wi-Fi network is GSA Guest. The password changes monthly. To get the current password, type “GSA Wireless” into any room on Slack and the current password will pop up.
 
 Non-guest wireless access is available using gsa-wireless and authenticating using your ENT username and password.
 
-### <a id="access-gsa-gov">Access GSA websites from inside the building?</a>
+### Access GSA websites from inside the building?
 
 First, make sure you’re on the gsa-wireless network, per the previous section. If you can access other websites but not .gsa.gov websites, keep your laptop open, go to the 4th floor, and you should suddenly be able to access .gsa.gov websites. You can come back upstairs and the new settings will stick. (Preposterous but true.)
 
-### <a id="charge-devices">Charge my laptop or phone?</a>
+### Charge my laptop or phone?
 
 Many of the power strips turn off automatically, so if you plug in your device but it doesn’t start charging, look for the small power button *next* to the power strip (it’s a little rounded rectangular switch).
 
-### <a id="standing-desks">Adjust a standing desk?</a>
+### Adjust a standing desk?
 
 Under the keyboard platform, you’ll find two levers. Compressing the right-side lever allows you to modify the tilt and height of the keyboard platform. Compressing the left-side lever causes the *entire* desk to immediately drop, so it’s wise to keep a hand on the rest of it and remove hot liquids and anything valuable first.
 
-### <a id="leave">Close up if I'm the last to leave for the day?</a>
+### Close up if I'm the last to leave for the day?
 
 If you're the last to leave your side of the office (north or south side), take care of these things on your side:
 
@@ -172,10 +172,10 @@ If you're the last to leave your side of the office (north or south side), take 
 * Turn off the lights. (You just have to turn off the big overhead lights; there are some small lights along the walls and in the team rooms that we can't turn off.)
 * Check the other side of the office if you have time.
 
-## <a id="where-are-the">Where are the&hellip;</a>
+## Where are the&hellip;
 
 
-### <a id="bathrooms">Bathrooms</a>
+### Bathrooms
 
 Men's and women’s bathrooms are just down the hall from the 18F office — walking away from the elevator bays of the building, the men’s room is on the left, and for the women’s keep going down the hall to just past the stairwell on the left.
 
@@ -183,17 +183,17 @@ There is an all-gender bathroom in the Nimitz Suite on the third floor (room 319
 
 An all-gender bathroom is also available for limited hours on Tuesday through Thursday in the Health Unit, which is in the basement. See the <a href="#health-center">health center</a> section for further details.
 
-### <a id="batteries">Batteries</a>
+### Batteries
 
 There are rechargeable batteries throughout the office space. You will find them plugged into sockets charging. Please replace the fresh ones you pulled out with the dead ones for recharging and re-use by another employee.
 
-### <a id="cafeteria">Cafeteria and snacks</a>
+### Cafeteria and snacks
 
 There&rsquo;s a cafeteria located on the first floor, serving breakfast and lunch. [Official hours](http://www.gsa.gov/portal/content/200155) (they say they close at 2 pm, but they usually close down around 1:50 pm). The cafeteria has a good salad bar.
 
 There are machines in the basement area with snacks as well as soft drinks.
 
-### <a id="kitchen">Kitchen</a>
+### Kitchen
 
 To find silverware and dishes: go to the kitchen down the hall (the one with the sink), look in the cabinets.
 
@@ -201,7 +201,7 @@ To find the refrigerators: There's one in the little kitchen room. There's also 
 
 What goes in the recycling, composting, and trash bins: The building's default brown paper towels go in compost. For details on other items, see [the recycle/compost/trash lists provided by SF's waste handling company](http://www.recologysf.com/index.php/for-businesses/commercial-recycling-compost-trash).
 
-### <a id="mailroom">Postal mail</a>
+### Postal mail
 
 Incoming mail is delivered as needed. Outgoing mail should be taken to the mailroom downstairs.
 
@@ -218,23 +218,23 @@ For FedEx and UPS, please use the address as usual:
 > Suite 5685<br/>
 > San Francisco, CA 94102
 
-## <a id="amenities">Amenities</a>
+## Amenities
 
-### <a id="gym-lockers-locker-rooms">Gym</a>
+### Gym
 
 There is a gym in the basement area ([Federal Fitness Center](http://www.federalfitnesscenter.com/)), with lockers and a locker room. To gain access, you will need to sign up at 450 Golden Gate — there are drop-in hours all day on Monday from 9 a.m. to 4 p.m., or you can make an appointment. If you have any questions about this, contact [Victor in Slack](https://18f.slack.com/messages/@vv).
 
-### <a id="interior-courtyard">Interior courtyard</a>
+### Interior courtyard
 
 The interior courtyard has Wi-Fi access so you can work outside!
 
-### <a id="transit-subsidy">Transit subsidy</a>
+### Transit subsidy
 
 All GSA employees are eligible for transit subsidies which cover the cost of your Clipper travel. To receive a transit subsidy, fill out [GSA form 3675](http://www.gsa.gov/portal/forms/download/115174). See more details [on InSite](https://insite.gsa.gov/portal/category/511801). Once your supervisor has signed the form, send it to [Lyvette Jones](mailto:lyvette.jones@gsa.gov) and cc [Victor Valdiviezo](mailto:victor.valdiviezo@gsa.gov).
 
 You will get a debit card (called a “Transerve card”) which you use to load your Clipper card each month.
 
-### <a id="health-center">Health center</a>
+### Health center
 
 The health unit is located in the basement. Hours are:
 
@@ -246,7 +246,7 @@ You can receive basic first aid, screenings, and flu shots. The phone number for
 
 The Health Unit also includes an all-gender bathroom.
 
-### <a id="helpful-contacts">Helpful contacts</a>
+### Helpful contacts
 
 * [50 UN Plaza Building Management](http://www.gsa.gov/portal/content/200391), including how to contact our Building Manager and Building Service Desk.
 * [50 UN Plaza Building Directory](http://www.gsa.gov/portal/category/107011), including additional helpful phone numbers.
@@ -255,11 +255,11 @@ The Health Unit also includes an all-gender bathroom.
 * [18F SF Mailing list](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/18f-sf)
 * [50 UN Plaza Mailing list](https://groups.google.com/a/gsa.gov/forum/#!forum/50unp)
 
-## <a id="who-works-here">Who works here?</a>
+## Who works here?
 
 We keep a list of [people who work in the San Francisco office](https://hub.18f.gov/locations/#SFO).
 
-## <a id="food-and-coffee">Food and coffee</a>
+## Food and coffee
 
 [Google Map](https://www.google.com/maps/d/u/0/viewer?mid=zMY1nJmKeGBU.kU147P2SgCmA) with lots of food and drink options near 50 UN Plaza.
 

--- a/_pages/about-us/offices/washington-dc.md
+++ b/_pages/about-us/offices/washington-dc.md
@@ -46,9 +46,9 @@ title: Washington, D.C.
   </table>  
 </div>
 
-##  <a id="getting-here">Getting here</a>
+## Getting here
 
-### <a id="from-the-airport">From the airport</a>
+### From the airport
 
 **Reagan Washington National Airport (DCA)** is the closest airport to D.C. (and GSA). If you&rsquo;re coming from DCA, you can take a cab (~$20) or ride the Metro, which is likely faster. Take the Blue line from the Ronald Reagan Washington National Airport station to Farragut West station. It should take approximately 15 minutes and cost ~$2.15. Once outside the Metro station, follow the directions under "Public Transit."
 
@@ -60,150 +60,150 @@ If you&rsquo;re coming from **Thurgood Marshall Baltimore-Washington Airport (BW
 - Ride an Amtrak train to Union Station (~$15). Your ticket is for a specified time and train, which can be problematic if your flight is delayed. From Union Station, take the Red line to Farragut North station.
 - Take the B30 express Metro bus ($7) to Greenbelt station on the Green Line. Take the Green Line to either Fort Totten or Gallery Place, and transfer to the Red Line. Take the Red Line to Farragut North.
 
-### <a id="walking">Walking</a>
+### Walking
 
 18F&rsquo;s Washington office is located two blocks from the White House, six blocks from the Farragut North station, and three blocks from the Farragut West Metro Station. If you&rsquo;d like to take an afternoon walk, the Smithsonian is three blocks away via 18th Street.
 
 
-### <a id="biking">Biking</a>
+### Biking
 
 Bike parking is free. The entrance to the bike room is via a ramp on E Street by Greenberry&rsquo;s Coffee. (There are two ramps into the 18F office. The one closer to 19th Street is the one you&rsquo;re looking for.) You must show your GSA ID to the guide and then take your bike down to the bike room in the big building at the center of the courtyard.
 
 There are also numerous Capital Bikeshare stations in the vicinity.
 
 
-### <a id="public-transit">Public transit</a>
+### Public transit
 
 Take the Metro Red Line to Farragut North, or take the Metro Orange/Blue Line to Farragut West. Exit the Metro on the 18th Street side and walk south on 18th Street about four blocks to F Street. The entrance to GSA is located at the middle of the building on F Street, between 18th and 19th Street.
 
-### <a id="parking">Parking </a>
+### Parking
 
 There are two parking garages near GSA on 18th Street, one on the right and one on the left just as you pass F Street, between F and G Streets. In addition, there are other parking garages on Pennsylvania Avenue, between 18th and 17th Street within walking distance of GSA.
 
 Parking at nearby garages tends to cost ~$14 for the first hour and then ~$21 for the second hour to a full day.
 
-### <a id="once-inside-gsa">Once inside GSA </a>
+### Once inside GSA
 
 When entering from the F Street entrance, continue straight past security down the hallway in front of you. At the end of the hallway, take the elevators up to floor four. Once out of the elevators, take two quick right turns and you&rsquo;ll be in the fourth floor infill. A map is here.
 
 
-## <a id="how-do-i">How do I&hellip;</a>
+## How do I&hellip;
 
 
-### <a id="enter-the-building">Enter the building for the first time? </a>
+### Enter the building for the first time?
 
 Enter through the main building entrance on F Street, tell the security guard you&rsquo;re here and provide them with a photo ID. (Note that pocket knives with blades longer than 2½" are prohibited.) Later on in the day (or soon after) you will have the opportunity to pick up your official GSA ID Badge.
 
 
-### <a id="enter-the-building-as-a-visitor">Enter the building if I&rsquo;m based in another office? </a>
+### Enter the building if I&rsquo;m based in another office?
 
 Your badge should get you in. If you&rsquo;re having trouble, call one of the points of contact listed above, or ask in [#dc](https://18f.slack.com/messages/dc/).
 
 
-### <a id="get-my-fingerprints">Get my fingerprints and badge? </a>
+### Get my fingerprints and badge?
 
 Fingerprinting and the photo for your badge take place immediately after security in room 1033. Badge pickup is on the first floor, in the library. After pickup, you'll need to get it activated in the basement.
 
-### <a id="attend-orientation">Attend GSA and 18F orientation </a>
+### Attend GSA and 18F orientation
 
 The location of onboarding differs based on how many people are coming into GSA. You will find out the exact location once you arrive at orientation.
 
-### <a id="mail-to-dc">Mail something to the office? </a>
+### Mail something to the office?
 
 Send mail to:
 > General Services Administration | 1800 F ST NW | Rm 4400 | Washington, DC 20405-0001 (you can add "ATTN: Name" at top).
 
-### <a id="access-after-hours">Access the building after hours? </a>
+### Access the building after hours?
 
 Go to the F Street entrance, where 24/7 access is available.
 
-### <a id="book-rooms">Book rooms for meetings? </a>
+### Book rooms for meetings?
 
 Depending on your needs, you might need different room accommodations. A cheat sheet for 18F conference rooms lives here. Avoid booking rooms 1470 and up on the first floor, as well as x3xx rooms &mdash; they&rsquo;re really far away from 18F and aren&rsquo;t easily accessible.
 
-### <a id="receive-visitors">Receive visitors? </a>
+### Receive visitors?
 
 If you're expecting a small group of US citizens (fewer than 15 or so), no advance action is required on your part. Let your guest(s) know to bring ID; they'll give your name and the 18F room number (4400) at the security desk. You'll have to go down and escort them up.
 
 If you're expecting a large group, or if the group includes non-US citizens, you should give security advance notice.
 
-### <a id="access-a-printer">Access a printer?</a>
+### Access a printer?
 
 Refer to [our printer information document](https://docs.google.com/document/d/1Ikw7kfeY10lnImZHN7zq5wNjaTRBdTPkZj4QG7-z3d0/edit#) for more details.
 
-### <a id="get-on-the">Get on the wireless? </a>
+### Get on the wireless?
 
 The guest wireless network in the building is GSA Guest. The password changes monthly. To obtain the current password, type &ldquo;GSA Wireless&rdquo; into any room on Slack and the current password will pop up.
 
 Non-guest wireless access is available using gsa-wireless and authenticating using your ENT username and password.
 
 
-## <a id="where-are-the">Where are the&hellip;</a>
+## Where are the&hellip;
 
 There are maps of the D.C. office in every elevator lobby.
 
 
-### <a id="bathrooms">Bathrooms </a>
+### Bathrooms
 
 Bathrooms are located at the end of both the 4100 and 4200 wings. Additional bathrooms are just outside the 4400 space in the 4100 wing.
 
-### <a id="mothers-rooms">Mother’s rooms</a>
+### Mother’s rooms
 
 Look for room 1232A at the back of the health center on the first floor. You don’t need to reserve it. If it’s in use, you can use the doctor’s office or one of the other rooms near the health clinic. After 4 p.m., you can access the mother’s room directly from the hallway, but the rest of the health center will be closed.
 
 There is a fridge inside the mother’s room and one outside the room as well. At the end of the day, if there’s any milk in the outer fridge, they’ll move it to the inner fridge.
 
-### <a id="batteries">Batteries </a>
+### Batteries
 
 If you need batteries for your keyboard or trackpad, there is a consolidated supply closet on the first floor of the building, in the 200 wing. There are also rechargeable batteries in a charger plugged into one of the columns in the 4462 area.
 
 
-### <a id="lockers">Lockers </a>
+### Lockers
 
 The lockers are in two spots. One set is by the couches the other by that large table on the E Street side. You will be assigned a locker if you work in D.C. so that you have a spot for personal belongings.
 
 
-### <a id="snacks">Snacks </a>
+### Snacks
 
 GSA has a small canteen on the first floor for snacks, yogurts, and coffee. Additionally, there are a series of three drawers for snack foods located within 18F infill that are stocked with snacks purchased with a collective private fund and available for members only. Ask in [#dc](https://18f.slack.com/messages/dc/) if you want to contribute and join.
 
 The DC fridge is cleaned out monthly on Fridays (dates are posted on the fridge), and all food (including containers) is thrown out.
 
 
-### <a id="spare-keyboards-mice">Spare keyboards and mice </a>
+### Spare keyboards and mice
 
 There are several of these located in one of the Gold Key drawers. Batteries can be found in one of the chargers nearby. Note that these will require you to setup bluetooth pairing to your laptop to use them and they may be paired with someone else&rsquo;s machine at first.
 
 
-### <a id="tissues">Tissues </a>
+### Tissues
 
 There is another fund for purchasing boxes of tissues in the winter months. Ask in [#dc](https://18f.slack.com/messages/dc/) if you want to contribute.
 
 
-### <a id="water">Water </a>
+### Water
 
 The water cooler in the infill is reserved for those who have contributed to the water cooler fund. Contact information for joining is on the cooler itself. Please remember to bring your own cup. In addition, there are water fountains by the bathrooms.
 
 
-## <a id="amenities">Amenities</a>
+## Amenities
 
 
-### <a id="childcare">Child care </a>
+### Child care
 
 Here are some [local child care facilities](http://www.gsa.gov/portal/content/101942#DC).
 
 
-### <a id="gym-lockers-locker-rooms">Gym, lockers, locker rooms </a>
+### Gym, lockers, locker rooms
 
 The gym is located in the basement. Make sure you bring your badge with you, as you&rsquo;ll need it to get back into the second wing. The easiest way to get there is by taking the old elevators at the F Street entrance down to the basement, walking slightly north, and then cutting across the parking lot (where the bike room entrance is) into the third wing hallway. The gym is on your left when you walk in, and the men&rsquo;s and women&rsquo;s locker rooms are down the long hallway to your right. If you want a locker, you can reach out to Tenant Support to reserve one by [emailing Tenant Support](mailto:1800Ftenantsupport@gsa.gov).
 
 
-### <a id="rooftop">Rooftop</a>
+### Rooftop
 
 Take the elevator to seventh floor for wireless and a beautiful view of the National Mall. The Northeast corner of the building does not have as fine a view, but it does have an overhead awning that better prevents glare on your laptop screen.
 
 
-### <a id="transit-subsidy">Transit subsidy </a>
+### Transit subsidy
 
 All GSA employees are eligible for transit subsidies, which cover the cost of your mass transportation travel. To receive a transit subsidy for MARC, VRE, and Commuter Buses, fill out GSA form 3675. The form asks for your supervisor&rsquo;s signature. For Metro, you need GSA form 3675A (it will have a &ldquo;SmarTrip Card Serial Number&rdquo; field in the upper right). You must already have a SmarTrip card and have registered it on the Metro website. It should be a distinct card from what you use for personal travel.
 
@@ -217,10 +217,10 @@ After you've obtained your supervisor&rsquo;s signature, [send the completed for
 - [Health Unit](https://insite.gsa.gov/portal/content/615454)
 - [OEO Assignments](https://docs.google.com/spreadsheets/d/1-7o3MIakF6OAMPyYqjfQyit8iBBbpXw6U6IxhhdNGRQ/edit#gid=673464213) (wing monitors, floor warden, etc.)
 
-### <a id="health-center">Health center </a>
+### Health center
 
 There is a [health center](https://insite.gsa.gov/portal/content/615454) on the first floor. They offer flu shots and have basic medicine.
 
-## <a id="food-and-coffee">Food and coffee</a>
+## Food and coffee
 
 [Google Map](https://www.google.com/maps/d/u/0/edit?mid=zMY1nJmKeGBU.kU147P2SgCmA) with lots of food and drink options.


### PR DESCRIPTION
Makes the hashes longer in some cases, but they are more consistent in that when they are auto-generated, they match the text in the heading.