### PR TITLE
Remove extraneous comma

### DIFF
--- a/_pages/welcome-to-18f/classes/benefits.md
+++ b/_pages/welcome-to-18f/classes/benefits.md
@@ -92,7 +92,7 @@ Please use [ALOHA](/gsa-tools-equipment-and-transit/#aloha) to request sick leav
 
 ### Annual leave
 
-An employee may use annual leave for vacations, rest, and relaxation, and personal business or emergencies. Annual leave accrues based on how long you&rsquo;ve worked for the government:
+An employee may use annual leave for vacations, rest and relaxation, and personal business or emergencies. Annual leave accrues based on how long you&rsquo;ve worked for the government:
 
 * Fewer than three years: four hours per pay period
 * Between three and 15 years: six hours per pay period


### PR DESCRIPTION
I'm not sure that "rest and relaxation" reads as a single conceptual unit (unlike "R&R"), making this awkward to some readers, but the simplest change that I can make to render this passage properly is to just eliminate the comma.