### PR TITLE
update myview.gsa.gov to horizon.gsa.gov

### DIFF
--- a/_pages/how-we-work/networks.md
+++ b/_pages/how-we-work/networks.md
@@ -48,11 +48,11 @@ If you have any questions, call IT at 202-501-4459.
 There are a few ways to access the GSA network remotely. Your colleagues prefer:
 
 - [AnyConnect](/anyconnect/), a desktop client
-- [myView](https://myview.gsa.gov/)'s HTML web interface
+- [Horizon](https://horizon.gsa.gov/)'s HTML web interface
 
 Alternatively, you can try one of these:
 
-- [VMware Horizon](/vmware-horizon/), a desktop client that connects to GSA myView
+- [VMware Horizon](/vmware-horizon/), a desktop client that connects to GSA Horizon
 - Citrix: Use [internal.anywhere.gsa.gov](https://internal.anywhere.gsa.gov/) when connected to VPN and [anywhere.gsa.gov](https://anywhere.gsa.gov/) when **not** connected to VPN.
 - [GSA Apps](http://gsa-apps.gsa.gov), a web interface
 

--- a/_pages/how-we-work/tools/vmware-horizon.md
+++ b/_pages/how-we-work/tools/vmware-horizon.md
@@ -6,7 +6,7 @@ VMware Horizon is a VPN client that we use to connect to GSA’s intranet.
 
 ## Setup
 
-New employees should have a GSA myView account, but if not:
+New employees should have a GSA VMware myView/Horizon account, but if not:
 
   1. Go to [servicedesk.gsa.gov](http://servicedesk.gsa.gov/).
   2. Sign in with your ENT username and password.
@@ -18,10 +18,10 @@ New employees should have a GSA myView account, but if not:
 
 ## Usage
 
-1. Once you have access, you can use myView through the web client or install the software from [https://myview.gsa.gov/](https://myview.gsa.gov/).
-2. Log into [otp.gsa.gov](https://otp.gsa.gov) with 2-factor authentication so you can get a code to enter at myview.gsa.gov along with your GSA password.
+1. Once you have access, you can use myView through the web client or install the software from [https://horizon.gsa.gov/](https://horizon.gsa.gov/).
+2. Log into [otp.gsa.gov](https://otp.gsa.gov) with 2-factor authentication so you can get a code to enter at horizon.gsa.gov along with your GSA password.
 
-Note: MyView allows for a virtual desktop in browser with no downloads.
+Note: myView/Horizon allows for a virtual desktop in browser with no downloads.
 
 
 #### Still have questions?


### PR DESCRIPTION
https://myview.gsa.gov no longer works for web VPN access. I just got a response from the IT Service Desk that we should instead be using https://horizon.gsa.gov for web VPN access. I confirmed and it does indeed work.