### PR TITLE
Add mailchimp/mandrill guide.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -268,6 +268,9 @@ navigation:
     - text: Mural.ly
       url: murally/
       internal: true
+    - text: MailChimp / Mandrill
+      url: mailchimp-mandrill/
+      internal: true
     - text: Slack
       url: slack/
       internal: true

--- a/_pages/how-we-work/tools/mailchimp-mandrill.md
+++ b/_pages/how-we-work/tools/mailchimp-mandrill.md
@@ -1,0 +1,22 @@
+---
+title: MailChimp / Mandrill
+---
+
+We use MailChimp and its Mandrill add-on to send transactional emails.
+
+## Communication
+
+* Slack: [#admins-mailchimp](https://18f.slack.com/messages/admins-mailchimp/)
+
+## <a id="setup">Setup</a>
+
+1. Create a [MailChimp](https://login.mailchimp.com/signup) account associated
+   with your GSA email address.
+2. File a new issue in the [18F/Infrastructure](https://github.com/18F/Infrastructure/issues/new)
+   repository. Title it **Please add me to the MailChimp account**, include
+   the GSA email address you used to sign up for MailChimp, and assign the
+   issue to [@afeld](https://github.com/afeld).
+
+Once you've been added to the shared account, you can log in to
+[Mandrill](https://mandrillapp.com/)--an add-on for MailChimp that allows you
+to send transactional emails.

--- a/_pages/how-we-work/tools/mailchimp-mandrill.md
+++ b/_pages/how-we-work/tools/mailchimp-mandrill.md
@@ -20,3 +20,7 @@ We use MailChimp and its Mandrill add-on to send transactional emails.
 Once you've been added to the shared account, you can log in to
 [Mandrill](https://mandrillapp.com/)--an add-on for MailChimp that allows you
 to send transactional emails.
+
+For more information on using MailChimp and/or Mandrill, such as
+details on SMTP configuration, please see the
+[Google Doc](https://docs.google.com/document/d/1XdedSaLHpV-b9rbFfnckRRYmatGJm-8jG5qzwfnWVfc/edit).


### PR DESCRIPTION
This adds a MailChimp/Mandrill guide based on the [C2 documentation](https://github.com/18F/C2/blob/master/doc/production.md#mandrill) and the [google doc](https://docs.google.com/document/d/1XdedSaLHpV-b9rbFfnckRRYmatGJm-8jG5qzwfnWVfc/edit#).

To do:

- [X] Add a link to the google doc for further information.
