### PR TITLE
Changing org code from "XF" to "TE"

### DIFF
--- a/_pages/about-us/general-contacts-and-listservs.md
+++ b/_pages/about-us/general-contacts-and-listservs.md
@@ -10,7 +10,7 @@ Information you might need for filling out GSA forms:
 
 * **Agency:** General Services Administration
 * **Organization:** Citizen Services and Innovative Technologies
-* **Correspondence symbol:** XF, XFA, XFB, or XFC. [More about correspondence symbols](https://insite.gsa.gov/portal/content/500188). Find yours by searching the [GSA directory](http://www.gsa.gov/portal/staffDirectory/searchStaffDirectory.action).
+* **Correspondence symbol:** TE (followed by several other letters, depending on your chapter/business unit) [More about correspondence symbols](https://insite.gsa.gov/portal/content/500188). Find yours by searching the [GSA directory](http://www.gsa.gov/portal/staffDirectory/searchStaffDirectory.action).
 * **Telework Agreement Location:** 00
 
 ## Team contact information


### PR DESCRIPTION
With the formation of TTS and the accompanying administrative order, all 18F staff have a new org code ("TE"). This pull request updates the handbook accordingly.

I don't try to guess the huge variety of letters that might follow "TE" (as we did before)...think it's best to say all our org codes just start with TE?