### PR TITLE
Updating Adobe Creative Cloud licensing

### DIFF
--- a/_pages/about-us/teams/design.md
+++ b/_pages/about-us/teams/design.md
@@ -129,7 +129,7 @@ And one more thing: before you start using any new tool that asks for access to 
 
 #### Drawing lines on a screen
 
-- **Creative Cloud:** Contact the Director of Design on Slack for a license. CC licenses are expensive, so please don’t request access unless you really do need it for your work. The wait is variable — it depends on whether our batch purchasing has caught up to our hiring.
+- **Adobe Creative Cloud:** email <mailto:18fsoftware@gsa.gov> for a license. CC licenses are expensive, so please don’t request access unless you really do need it for your work. The wait is variable — it depends on whether our batch purchasing has caught up to our hiring.
 - **InVision:** For prototyping. For a license, email <mailto:18fsoftware@gsa.gov>.
 - **OmniGraffle:** For a license, email <mailto:18fsoftware@gsa.gov>. The wait is variable — it depends on whether our batch purchasing has caught up to our hiring.
 - **Sketch:** For a license, email <mailto:18fsoftware@gsa.gov>. You can get started with a trial version [immediately](http://bohemiancoding.com/sketch/). Upgrade to the full version whenever you get the license.


### PR DESCRIPTION
updating handbook with process change : no longer routed through the director, but rather through the software email address