### PR TITLE
Adding the security incident guide to the homepage; updating guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -349,6 +349,9 @@ navigation:
   - text: Promotions
     url: promotions/
     internal: true
+  - text: Security incidents
+    url: security-incidents/
+    internal: true
   - text: Term extensions
     url: term-extensions/
     internal: true

--- a/_pages/policies/security-incidents.md
+++ b/_pages/policies/security-incidents.md
@@ -11,9 +11,9 @@ To report a security incident, follow all of the steps below:
 
 1. Report the incident in the [#incident-response](https://18f.slack.com/messages/incident-response) Slack channel.
 
-1. For anything that _isn't_ a phishing attempt, text Kimber Dowsett, the 18F Infrastructure Security Architect, at 202-316-9041 with a _very short description_ of the incident.
+1. For anything that _isn't_ a phishing attempt, [send a Slack DM to Kimber Dowsett (@kimber](https://18f.slack.com/messages/@kimber/), the 18F Infrastructure Security Architect, with a _very short description_ of the incident.
 
-1. Open a [GitHub Issue](https://github.com/18F/security-incidents/issues/new) in this repo describing the incident in **as much detail as possible**.
+1. Open a [GitHub issue in the security-incidents repository](https://github.com/18F/security-incidents/issues/new) describing the incident in **as much detail as possible**.
   * Keep this issue up to date with appropriately summarized actions or information from interactions with GSA.
   * If needed, create a GSA Google Doc to track sensitive information that can't be shared in Slack/GitHub. Put a hyperlink to the GSA Google Doc in the top summary of the GitHub Issue.
 
@@ -27,14 +27,14 @@ Please note that incidents need to be reported *within one hour* of being identi
 
 ## What is an incident?
 
-First, it's important to note: it's always OK to err on the side of reporting! TTS's and GSA's IR teams are good at their job, and are totally used to false alarms. You'll never get in trouble for pinging them about something that turns out not to be an issue! Indeed, *you'll never get in trouble for pinging IR at all*. The most effective security "early warning system" is attentive staff, so "report early, report often"!
+First, it's important to note: it's always OK to err on the side of reporting! TTS's and GSA's IR teams are good at their job, and they are totally used to false alarms. You'll never get in trouble for pinging them about something that turns out not to be an issue! Indeed, *you'll never get in trouble for pinging IR at all*. The most effective security "early warning system" is attentive staff, so "report early, report often"!
 
 On to the answer to "what is an incident?": in a nutshell, an incident is anything that compromises (or could compromise) our "CIA": **Confidentiality, Integrity, or Availability.**
 
-- **Confidentiality** means: "secrets". So personal information (PII) -- names, phone numbers, social security numbers, etc -- is one very important secret, but so are your passwords, service credentials, internal non-public documents, etc. Any time you suspect that any confidential information may have been leaked outside 18F, you should open an incident.
+- **Confidentiality** means: "secrets". So personal information (PII) — names, phone numbers, social security numbers, etc — is one very important secret, but so are your passwords, service credentials, internal non-public documents, etc. Any time you suspect that any confidential information may have been leaked outside 18F, you should open an incident.
 
-- **Integrity** means the the soundness/fitness of purpose of our systems or information. So if a backup was lost, or if a app stopped logging for a while, or if some documents got deleted -- those are integrity issues. Sometimes these can indicate deeper incidents (like an attacker deleting logs to cover their tracks), so it's important to report these, as well.
+- **Integrity** means the the soundness/fitness of purpose of our systems or information. So if a backup was lost, or if a app stopped logging for a while, or if some documents got deleted — those are integrity issues. Sometimes these can indicate deeper incidents (like an attacker deleting logs to cover their tracks), so it's important to report these, as well.
 
-- Finally, **availability** means the availability of the services we provide. So if an app goes down, if something we expect to be running stops running -- those are availability issues. Note that this only refers to production systems (it's fine if your demo app crashes), and also only to unexpected downtime. If you decide to shut something down temporarily for maintenance -- go for it, not an incident.
+- Finally, **availability** means the availability of the services we provide. So if an app goes down, if something we expect to be running stops running — those are availability issues. Note that this only refers to production systems (it's fine if your demo app crashes), and also only to unexpected downtime. If you decide to shut something down temporarily for maintenance — go for it, not an incident.
 
-Remember: it's totally OK -- and encouraged -- to fail towards the side of reporting something. Organizations with really healthy IR systems see a lot of false alarms, and a lot of very low severity reports. This is good, because it indicates that people feel comfortable reporting day-to-day issues. The more we do it, the better we'll get at it. And this is ultimately the goal, because then when something really serious happens, we'll be well-practiced at handling it smoothly and efficiently.
+Remember: it's totally OK — and encouraged — to fail towards the side of reporting something. Organizations with really healthy IR systems see a lot of false alarms, and a lot of very low severity reports. This is good, because it indicates that people feel comfortable reporting day-to-day issues. The more we do it, the better we'll get at it. And this is ultimately the goal, because then when something really serious happens, we'll be well-practiced at handling it smoothly and efficiently.

--- a/_pages/policies/security-incidents.md
+++ b/_pages/policies/security-incidents.md
@@ -1,6 +1,8 @@
-# Security Incidents
+---
+title: Security incidents
+---
 
-Something went "bump" in the night (or the day)? This document explains what to do when responding to a security incident (see [What is an Incident](#what-is-an-incident) below if you need help determining whether something "counts" as an incident or not).
+Something went "bump" in the night (or the day)? This document explains what to do when responding to a security incident. See [What is an incident?](#what-is-an-incident) if you need help determining whether something counts as an incident.
 
 # Reporting Process
 To report a security incident, follow all of the steps below:
@@ -11,7 +13,7 @@ To report a security incident, follow all of the steps below:
 
 1. Report the incident in the [#incident-response](https://18f.slack.com/messages/incident-response) Slack channel.
 
-1. For anything that _isn't_ a phishing attempt, [send a Slack DM to Kimber Dowsett (@kimber](https://18f.slack.com/messages/@kimber/), the 18F Infrastructure Security Architect, with a _very short description_ of the incident.
+1. For anything that _isn't_ a phishing attempt, [send a Slack DM to Kimber Dowsett (@kimber)](https://18f.slack.com/messages/@kimber/), the 18F Infrastructure Security Architect, with a _very short description_ of the incident.
 
 1. Open a [GitHub issue in the security-incidents repository](https://github.com/18F/security-incidents/issues/new) describing the incident in **as much detail as possible**.
   * Keep this issue up to date with appropriately summarized actions or information from interactions with GSA.
@@ -21,7 +23,7 @@ To report a security incident, follow all of the steps below:
 
 1. If the incident involves [cloud.gov](https://cloud.gov/), start [following the additional checklist here](https://docs.cloud.gov/ops/security-ir-checklist/).
 
-1. Following notification to GSA, the Incident Response team will contact you requesting more information. If the incident is related to cloud.gov, please ensure they CC (cloud-gov-support@gsa.gov), but try to drive as much of the conversation back to [#incident-response](https://18f.slack.com/messages/incident-response) in Slack as possible.
+1. Following notification to GSA, the Incident Response team will contact you requesting more information. If the incident is related to cloud.gov, please ensure they CC the cloud.gov team (cloud-gov-support@gsa.gov), but try to drive as much of the conversation back to [#incident-response](https://18f.slack.com/messages/incident-response) in Slack as possible.
  
 Please note that incidents need to be reported *within one hour* of being identified. This isn't "within an hour of happening", but "within one hour of you becoming aware of the incident". The idea is to make sure we're promptly looping in the right people. So, as soon as you're aware of a problem, follow the above steps.
 


### PR DESCRIPTION
* Fixing security incident guide title formatting so that this will show up as a live page
* Adding Security Incident guide link to the handbook homepage
* Updating contact info at the guidance of @kimberbat
* Minor formatting/phrasing fixes

cc @NoahKunin @jacobian