### PR TITLE
Hotfix to remove Murally invitation link

### DIFF
--- a/_pages/how-we-work/tools/murally.md
+++ b/_pages/how-we-work/tools/murally.md
@@ -6,7 +6,7 @@ Mural.ly is a collaborative whiteboard and sticky note tool.
 
 ## Setup
 
-Because Mural.ly is a web application, there’s no installation necessary. You will need to set up an account, however. If you don’t already have a Mural.ly account, visit [this link](http://mrl.li/mnEPxzBV) and create an account with your GSA email address. In order to have access to all 18F public rooms and create your own rooms, you need an admin to give you those permissions. Post a link the the #admins-mural channel to get access.
+Because Mural.ly is a web application, there’s no installation necessary. You will need to set up an account, however. If you don’t already have a Mural.ly account, ask in Slack for the invitation link, and from there, create an account with your GSA email address. In order to have access to all 18F public rooms and create your own rooms, you need an admin to give you those permissions. Post a link the the #admins-mural channel to get access.
 
 ## Usage
 


### PR DESCRIPTION
This removes the direct link to join the 18F Murally account.