### PR TITLE
use redirect_url for redirect layout instead

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -20,7 +20,7 @@
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-  <meta http-equiv="refresh" content="0;URL='{{ page.url }}">
+  <meta http-equiv="refresh" content="0;URL='{{ page.redirect_url }}">
 
 </head>
 

--- a/_pages/about-us/teams/infrastructure.md
+++ b/_pages/about-us/teams/infrastructure.md
@@ -1,5 +1,5 @@
 ---
 title: Infrastructure
-url: /tech-portfolio/
+redirect_url: /tech-portfolio/
 layout: redirect
 ---

--- a/_pages/how-we-work/tools/google-hangouts.md
+++ b/_pages/how-we-work/tools/google-hangouts.md
@@ -1,5 +1,5 @@
 ---
 title: Google Hangouts
-url: /google-meet/
+redirect_url: /google-meet/
 layout: redirect
 ---

--- a/_pages/how-we-work/tools/office.md
+++ b/_pages/how-we-work/tools/office.md
@@ -1,5 +1,5 @@
 ---
 title: Office
-url: https://docs.google.com/document/d/1ca1Ka0R9XBaxRhpagGUKPgVzO589_bx89GWMogQintM/edit?usp=sharing
+redirect_url: https://docs.google.com/document/d/1ca1Ka0R9XBaxRhpagGUKPgVzO589_bx89GWMogQintM/edit?usp=sharing
 layout: redirect
 ---

--- a/_pages/policies/business-and-ops-policies/billing_policy.md
+++ b/_pages/policies/business-and-ops-policies/billing_policy.md
@@ -1,5 +1,5 @@
 ---
 title: Billing policy
-url: https://docs.google.com/document/d/1Y5MP1jmCuc43pW35zXF-lvQrwDFA9YgQfviWtFcf4ao/edit#gid=0
+redirect_url: https://docs.google.com/document/d/1Y5MP1jmCuc43pW35zXF-lvQrwDFA9YgQfviWtFcf4ao/edit#gid=0
 layout: redirect
 ---

--- a/_pages/policies/conduct-policies/code-of-conduct.md
+++ b/_pages/policies/conduct-policies/code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
 title: Code of conduct
-url: https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md
+redirect_url: https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md
 layout: redirect
 ---

--- a/_pages/policies/tech-policies/open-source.md
+++ b/_pages/policies/tech-policies/open-source.md
@@ -1,5 +1,5 @@
 ---
 title: Open source policy
-url: https://github.com/18F/open-source-policy/blob/master/policy.md
+redirect_url: https://github.com/18F/open-source-policy/blob/master/policy.md
 layout: redirect
 ---

--- a/_pages/redirects/buddy-handbook.md
+++ b/_pages/redirects/buddy-handbook.md
@@ -1,5 +1,5 @@
 ---
 title: Buddy Handbook
-url: https://docs.google.com/document/d/13mY93EQFU3csWnY-X7orJdgMIhVhxm1JLb4mf7_l_to/edit#
+redirect_url: https://docs.google.com/document/d/13mY93EQFU3csWnY-X7orJdgMIhVhxm1JLb4mf7_l_to/edit#
 layout: redirect
 ---

--- a/_pages/redirects/employee-assistance-program.md
+++ b/_pages/redirects/employee-assistance-program.md
@@ -1,6 +1,5 @@
 ---
 title: Employee Assistance Program (EAP)
-url: /benefits/#employee-assistance-program
+redirect_url: /benefits/#employee-assistance-program
 layout: redirect
 ---
-

--- a/_pages/redirects/google-docs.md
+++ b/_pages/redirects/google-docs.md
@@ -1,5 +1,5 @@
 ---
 title: Google Docs
-url: /google-drive/
+redirect_url: /google-drive/
 layout: redirect
 ---

--- a/_pages/redirects/mission.md
+++ b/_pages/redirects/mission.md
@@ -1,5 +1,5 @@
 ---
 title: Mission
-url: https://18f.gsa.gov/about/#our-mission
+redirect_url: https://18f.gsa.gov/about/#our-mission
 layout: redirect
 ---

--- a/_pages/redirects/opp-org-chart.md
+++ b/_pages/redirects/opp-org-chart.md
@@ -1,5 +1,5 @@
 ---
 title: Office of Products and Programs (OPP) org chart
-url: https://docs.google.com/presentation/d/10Qfq1AaQh74q76Pik99kQedvshLBo0qLWZGsH-nrV0w/edit
+redirect_url: https://docs.google.com/presentation/d/10Qfq1AaQh74q76Pik99kQedvshLBo0qLWZGsH-nrV0w/edit
 layout: redirect
 ---

--- a/_pages/redirects/org-chart.md
+++ b/_pages/redirects/org-chart.md
@@ -1,5 +1,5 @@
 ---
 title: 18F org chart
-url: https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit?usp=sharing
+redirect_url: https://docs.google.com/presentation/d/189TanLPSFF9MWvNr6VdfUvhBAWBSXeoCSGD2ZXRDm3s/edit?usp=sharing
 layout: redirect
 ---

--- a/_pages/redirects/tts-org-chart.md
+++ b/_pages/redirects/tts-org-chart.md
@@ -1,5 +1,5 @@
 ---
 title: Technology Transformation Service (TTS) org chart
-url: https://docs.google.com/presentation/d/1Z5hxEcyMURBFseQ2CaEAWYYRA9sgELPeIH-qzi4byBw/edit#
+redirect_url: https://docs.google.com/presentation/d/1Z5hxEcyMURBFseQ2CaEAWYYRA9sgELPeIH-qzi4byBw/edit#
 layout: redirect
 ---

--- a/_pages/welcome-to-TTS/classes/intro-to-the-diversity-guild.md
+++ b/_pages/welcome-to-TTS/classes/intro-to-the-diversity-guild.md
@@ -1,5 +1,5 @@
 ---
 title: Intro to the Diversity Guild
-url: /diversity
+redirect_url: /diversity
 layout: redirect
 ---


### PR DESCRIPTION
Fixes https://github.com/18F/handbook/issues/1431

The issue is that `page.url` is a generated relative url of the given page, and so redirecting to self yields an infinite loop. Renaming to `page.redirect_url` seems clearer and easiest in this case. Impacts all pages that use a redirect layout.