### PR TITLE
allow CORs to determine contractors' access

### DIFF
--- a/_pages/software-tools/slack-admin.md
+++ b/_pages/software-tools/slack-admin.md
@@ -26,7 +26,7 @@ Note this does _not_ include:
 - The general public, for which we have [dedicated channels]({{site.baseurl}}/slack/#public-channels)
 - Other feds who we are not working with directly
 
-Contractors' level of access will be determined by the Contracting Officer (CO). By default, **contractors who are "embedded" in TTS (working on TTS projects most or full-time) can be added as full members, while other collaborators should be added as single or multi-channel guests**, as appropriate.
+A contractor's level of access will be determined by their Contracting Officer (CO) or Contracting Officer Representative (COR). By default, **contractors who are "embedded" in TTS (working on TTS projects most or full-time) can be added as full members, while other collaborators should be added as single or multi-channel guests**, as appropriate. Have the CO/COR be the one to fill out the [user request form](https://docs.google.com/forms/d/e/1FAIpQLSfYQ-D82rIGwbCmwF3kAQERqczi5syVGq6GtmQNR6fhxRAA2Q/viewform?usp=sf_link).
 
 Additonal exceptions, including a small number of close TTS collaborators at GSA, may be added as full Slack members at the discretion of the Technology Director. Examples might include the Chief Information Officer or FAS Commissioner. Ask in [#admins-slack](https://gsa-tts.slack.com/messages/admins-slack) if you'd like to add someone to this category.
 


### PR DESCRIPTION
This is a change in policy; just looking for feedback on the clarity.