### PR TITLE
Update code-of-conduct.md

### DIFF
--- a/about-us/code-of-conduct.md
+++ b/about-us/code-of-conduct.md
@@ -32,7 +32,7 @@ It would be impossible to list everything staff can do to create a more welcomin
 - Listen carefully and actively.
 - Ask questions, and seek to understand your partners&#39; context.
 - Encourage other people to listen as much as they speak.
-- Treat other people&#39;s identities and cultures with respect. Make an effort to say people&#39;s names correctly and refer to them by their chosen pronouns.
+- Treat other people&#39;s identities and cultures with respect. Make an effort to say people&#39;s names correctly and refer to them by their stated pronouns.
 
 ## Unacceptable Behavior
 


### PR DESCRIPTION
In reusing the TTS code of conduct for a project, we noticed that it uses the language `chosen pronouns`. We recommend changing this language to `stated pronouns`. 

Language like `preferred pronouns` or `chosen pronouns` suggests that pronouns are an optional preference, which is not true; they're a reflection of a person's identity that others should respect. This edit (hopefully) makes this more clear.

cc @annepetersen 
