### PR TITLE
Adding `Federal holidays` to the OOO line on Tock handbook page

### DIFF
--- a/pages/tools/tock.md
+++ b/pages/tools/tock.md
@@ -13,6 +13,7 @@ redirect_from:
 - **Out of Office - #670:** Any time you are out of office for less than 3
   weeks. Including:
 
+  - Federal holidays,
   - Vacations,
   - Sick leave,
   - Administrative leave,


### PR DESCRIPTION
## Changes proposed in this pull request:
Guidance in the Tock handbook page mentions billing federal holidays to the `Out of Office - #670` bucket in Tock. However, this is not included in the bulleted list at the top of the page. Adding it here for clarity/consistency.

## security considerations
None.
